### PR TITLE
Switch JSON serialization to camel case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **BREAKING CHANGE** Types now use JSON tags which match Kubernetes convention, with naming using camel case rather
+than snake case. For example the Resource Metric field `PodMetricsInfo` is now serialized as `podMetricsInfo` rather
+than `pod_metrics_info`.
 
 ## [v3.0.0] - 2024-03-21
 ### Changed

--- a/metrics/external/external.go
+++ b/metrics/external/external.go
@@ -28,6 +28,6 @@ import (
 // service, or QPS from loadbalancer running outside of cluster).
 type Metric struct {
 	Current       value.MetricValue `json:"current,omitempty"`
-	ReadyPodCount *int64            `json:"ready_pod_count,omitempty"`
+	ReadyPodCount *int64            `json:"readyPodCount,omitempty"`
 	Timestamp     time.Time         `json:"timestamp,omitempty"`
 }

--- a/metrics/object/object.go
+++ b/metrics/object/object.go
@@ -26,6 +26,6 @@ import (
 // Metric (Object) is a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).
 type Metric struct {
 	Current       value.MetricValue `json:"current,omitempty"`
-	ReadyPodCount *int64            `json:"ready_pod_count,omitempty"`
+	ReadyPodCount *int64            `json:"readyPodCount,omitempty"`
 	Timestamp     time.Time         `json:"timestamp,omitempty"`
 }

--- a/metrics/podmetrics/podmetrics.go
+++ b/metrics/podmetrics/podmetrics.go
@@ -21,9 +21,9 @@ import "time"
 
 // Metric contains pod metric value (the metric values are expected to be the metric as a milli-value)
 type Metric struct {
-	Timestamp time.Time
-	Window    time.Duration
-	Value     int64
+	Timestamp time.Time     `json:"timestamp"`
+	Window    time.Duration `json:"window"`
+	Value     int64         `json:"value"`
 }
 
 // MetricsInfo contains pod metrics as a map from pod names to MetricsInfo

--- a/metrics/pods/pods.go
+++ b/metrics/pods/pods.go
@@ -27,10 +27,10 @@ import (
 // Metric (Pods) is a metric describing each pod in the current scale target (for example,
 // transactions-processed-per-second).  The values will be averaged together before being compared to the target value.
 type Metric struct {
-	PodMetricsInfo podmetrics.MetricsInfo `json:"pod_metrics_info"`
-	ReadyPodCount  int64                  `json:"ready_pod_count"`
-	IgnoredPods    sets.String            `json:"ignored_pods"`
-	MissingPods    sets.String            `json:"missing_pods"`
-	TotalPods      int                    `json:"total_pods"`
+	PodMetricsInfo podmetrics.MetricsInfo `json:"podMetricsInfo"`
+	ReadyPodCount  int64                  `json:"readyPodCount"`
+	IgnoredPods    sets.String            `json:"ignoredPods"`
+	MissingPods    sets.String            `json:"missingPods"`
+	TotalPods      int                    `json:"totalPods"`
 	Timestamp      time.Time              `json:"timestamp,omitempty"`
 }

--- a/metrics/resource/resource.go
+++ b/metrics/resource/resource.go
@@ -28,11 +28,11 @@ import (
 // in the current scale target (e.g. CPU or memory).  Such metrics are built in to Kubernetes, and have special scaling
 // options on top of those available to normal per-pod metrics (the "pods" source).
 type Metric struct {
-	PodMetricsInfo podmetrics.MetricsInfo `json:"pod_metrics_info"`
+	PodMetricsInfo podmetrics.MetricsInfo `json:"podMetricsInfo"`
 	Requests       map[string]int64       `json:"requests"`
-	ReadyPodCount  int64                  `json:"ready_pod_count"`
-	IgnoredPods    sets.String            `json:"ignored_pods"`
-	MissingPods    sets.String            `json:"missing_pods"`
-	TotalPods      int                    `json:"total_pods"`
+	ReadyPodCount  int64                  `json:"readyPodCount"`
+	IgnoredPods    sets.String            `json:"ignoredPods"`
+	MissingPods    sets.String            `json:"missingPods"`
+	TotalPods      int                    `json:"totalPods"`
 	Timestamp      time.Time              `json:"timestamp,omitempty"`
 }

--- a/metrics/value/value.go
+++ b/metrics/value/value.go
@@ -20,5 +20,5 @@ package value
 // MetricValue is a representation of a computed value for a metric, can be either a raw value or an average value
 type MetricValue struct {
 	Value        *int64 `json:"value,omitempty"`
-	AverageValue *int64 `json:"average_value,omitempty"`
+	AverageValue *int64 `json:"averageValue,omitempty"`
 }


### PR DESCRIPTION
Resolves #18 

JSON serialization of fields uses camel case instead of snake case.